### PR TITLE
docs: align documentation with recent changes (auto-generated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,34 +5,58 @@
 This is an implementation of the ESA [Major TOM](https://github.com/ESA-PhiLab/Major-TOM) equal area grid in Go.  
 This code is based on work in the ESA-PhiLab repository, specifically [here](https://github.com/ESA-PhiLab/Major-TOM/blob/main/src/grid.py)
 
+## Requirements
 
-## Usage: 
+- Go 1.26.0 or later
+- Module path: `github.com/earth-genome/mtgrid` (import the `majortom` subpackage for the public API)
 
-Also see [tests](majortom/mtgrid_test.go) 
+## Usage
+
+Also see [tests](majortom/mtgrid_test.go) and the [API reference](docs/api.md).
 
 ```go
 package main
 
 import (
-    "github.com/earth-genome/mtgrid"
+	"fmt"
+
+	"github.com/earth-genome/mtgrid/majortom"
+	"github.com/paulmach/orb"
 )
 
-func main(){
+func main() {
+	// Create a simple polygon; this is a 1/10th-of-a-degree square.
+	p := orb.Polygon{{{0.0, 0.0}, {0.0, 0.1}, {0.1, 0.1}, {0.1, 0.0}, {0.0, 0.0}}}
 
-	//create a simple polygon, this is 1/10th of a degree square
-	p := orb.Polygon{{{0.0, 0.0},{0.0, 0.1},{0.1, 0.1},{0.1, 0.0},{0.0, 0.0}}}
-	//instantiate a new grid with overlaps
-    grid := NewGrid(320, true)
-	//generate cells that cover the area
-    cells, _ := grid.GenerateGridCells(&p)
-		//do something with cells 
+	// Instantiate a grid with 320 m cells and overlap enabled.
+	grid := majortom.NewGrid(320, true)
+
+	// Generate cells that intersect the area of interest.
+	cells, _ := grid.GenerateGridCells(&p)
 	for _, cell := range cells {
-		fmt.Printf("cell id %s", cell.Id())
-    }
+		fmt.Printf("cell id %s\n", cell.Id())
+	}
+
+	// Look up a cell by geohash ID (longer IDs are truncated to 11 characters).
+	cell, _ := grid.CellFromId("dr19n8ggbf9")
+
+	// Map a prior-grid cell ID to the current primary cell.
+	migrated, _ := grid.MigrateCellId("dr18zj1ntew")
+
+	_, _ = cell, migrated
 }
-
-
 ```
+
+### Public API
+
+| Method | Description |
+|--------|-------------|
+| `NewGrid(size, overlap)` | Create a grid. `size` is the nominal cell edge length in **meters**; `overlap` enables half-cell-offset overlap cells. |
+| `GenerateGridCells(geo)` | Return all grid cells that intersect an `orb.Geometry` (polygon, multipolygon, etc.). |
+| `CellFromId(id)` | Look up a cell by geohash ID. IDs longer than 11 characters are truncated before lookup. |
+| `MigrateCellId(oldId)` | Map a cell ID from a prior grid version to the current grid's primary cell. |
+
+Each `GridCell` exposes an `Id()` method that returns an **11-character geohash** derived from the cell centroid. When `overlap` is `true`, additional cells offset by half the lat/lon spacing are generated alongside the primary grid.
 
 Before:
 ![Before](imgs/before.png)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,60 @@
+# API reference
+
+The public API lives in the `majortom` package (`github.com/earth-genome/mtgrid/majortom`).
+
+## Types
+
+### `GridCell`
+
+A grid cell represented as an `orb.Polygon` with a pre-computed geohash identifier.
+
+- **`Id() string`** — Returns the cell's 11-character geohash ID, encoded from the polygon centroid at precision 11.
+
+### `MajorTomGrid`
+
+An equal-area geographical grid aligned with the [ESA Major TOM](https://github.com/ESA-PhiLab/Major-TOM) reference implementation. Latitude and longitude grid lines match the ESA `linspace` + `mod` scheme; the equator and prime meridian fall on grid lines where applicable.
+
+## Functions
+
+### `NewGrid(size uint64, overlap bool) *MajorTomGrid`
+
+Construct a grid instance.
+
+| Parameter | Description |
+|-----------|-------------|
+| `size` | Nominal cell edge length in **meters** (e.g. `320` for 320 m cells). |
+| `overlap` | When `true`, generate additional cells offset by half the lat/lon spacing. When `false`, only primary (non-overlapping) cells are produced. |
+
+## Methods
+
+### `GenerateGridCells(geo orb.Geometry) ([]GridCell, error)`
+
+Divide the area of interest into grid cells and return those that geometrically intersect the input geometry.
+
+- Accepts any `orb.Geometry` value (e.g. `orb.Polygon`, `*orb.Polygon`, `orb.MultiPolygon`).
+- Uses the geometry's bounding box to determine the row/column search space, then applies precise intersection checks via `github.com/tingold/orb-predicates`.
+- Row processing runs concurrently; results are collected per row to minimize lock contention.
+- Returns an error if the geometry is `nil`.
+
+### `CellFromId(id string) (*GridCell, error)`
+
+Retrieve a grid cell from its geohash ID.
+
+- Computes the row/column index directly from the geohash centroid rather than scanning all cells in the area.
+- If `id` is longer than 11 characters, it is **truncated to the first 11 characters** before lookup.
+- Searches the computed cell and its immediate row/column neighbors to handle floating-point edge cases.
+- When overlap mode is enabled, also checks overlap-offset cells.
+- Returns an error if the geohash cannot be decoded or no matching cell is found.
+
+### `MigrateCellId(oldId string) (*GridCell, error)`
+
+Map a cell ID from a prior grid version to the current grid's **primary** (non-overlap) cell.
+
+- Decodes the geohash to recover the approximate centroid of the old cell.
+- Returns the primary cell in the current grid that contains that centroid.
+- If `oldId` is longer than 11 characters, it is truncated to 11 characters. The ID must be at least 11 characters after truncation.
+- Returns an error if the ID is too short or the geohash cannot be decoded.
+
+## Cell IDs
+
+All cell IDs are **11-character geohashes** (`geohashPrecision = 11`), derived from each cell polygon's centroid. This precision is used consistently for ID generation, lookup, and migration.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
At HEAD (ef709359) the latest push (f6fd6e5..ef709359) changed only .github/workflows/notify-internal-docs.yml, but watched paths go.mod and majortom/** changed substantially since README.md was last updated (f01b3ea): go.mod now declares module github.com/earth-genome/mtgrid and go 1.26.0 with github.com/tingold/orb-predicates v0.1.0, and majortom/mtgrid.go adds ESA-aligned grid math, concurrent GenerateGridCells accepting orb.Geometry (with orb-predicates intersection checks), CellFromId with 11-character geohash truncation, and MigrateCellId for prior-grid ID migration. README.md still shows a non-compiling example importing github.com/earth-genome/mtgrid without the majortom subpackage, omitting github.com/paulmach/orb, and calling unqualified NewGrid; it documents only a basic GenerateGridCells polygon case and never mentions Go 1.26.0, CellFromId, MigrateCellId, geohash ID precision, or overlap/non-overlap semantics. AGENTS.md (updated at 25e467d) contains only the ei-internal-docs org stanza with no API or module guidance, and no docs/**/*.md or agents.md files exist to cover the new behavior.

## Changes

- **README.md** — Fixed usage example imports, added Requirements and Public API sections.
- **docs/api.md** — New API reference for `MajorTomGrid`, `GridCell`, and all public methods.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ba4f270-4796-4a2b-b849-1233ad83d717?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ba4f270-4796-4a2b-b849-1233ad83d717&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

